### PR TITLE
Fix code scanning alert no. 7: Disabling certificate validation

### DIFF
--- a/libs/scully/src/lib/utils/httpGetJson.ts
+++ b/libs/scully/src/lib/utils/httpGetJson.ts
@@ -31,7 +31,6 @@ export function httpGetJson(
   You can ignore the warning (TLS) or run scully with --no-warning
 ****************************************************************************************`);
   }
-  process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
   const httpGet = isSSL ? getHttps : get;
   return new Promise((resolve, reject) => {
     const { pathname, hostname, port, protocol, search, hash } = new URL(url);


### PR DESCRIPTION
Fixes [https://github.com/akaday/symmetrical-octo-barnacle/security/code-scanning/7](https://github.com/akaday/symmetrical-octo-barnacle/security/code-scanning/7)

To fix the problem, we need to ensure that certificate validation is not disabled. This can be achieved by removing the line that sets `process.env['NODE_TLS_REJECT_UNAUTHORIZED']` to `'0'`. Instead, we should rely on the default behavior of Node.js, which validates certificates. If there is a need to handle self-signed certificates or other specific cases, we should use a more secure approach, such as providing a custom `https.Agent` with the appropriate settings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
