### PR TITLE
Fix code scanning alert no. 16: Missing rate limiting

### DIFF
--- a/libs/scully/package.json
+++ b/libs/scully/package.json
@@ -36,7 +36,8 @@
     "ws": "^8.5.0",
     "js-yaml": "^4.1.0",
     "yamljs": "^0.3.0",
-    "yargs": "^17.2.1"
+    "yargs": "^17.2.1",
+    "express-rate-limit": "^7.4.1"
   },
   "optionalDependencies": {
     "asciidoctor.js": "^1.5.9"


### PR DESCRIPTION
Fixes [https://github.com/akaday/symmetrical-octo-barnacle/security/code-scanning/16](https://github.com/akaday/symmetrical-octo-barnacle/security/code-scanning/16)

To fix the problem, we will introduce rate limiting to the Express server using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests a client can make to the server within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `staticServer.ts` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the routes, including the one using `handleUnknownRoute`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
