### PR TITLE
Fix code scanning alert no. 3: Reflected cross-site scripting

### DIFF
--- a/libs/scully/package.json
+++ b/libs/scully/package.json
@@ -37,7 +37,8 @@
     "js-yaml": "^4.1.0",
     "yamljs": "^0.3.0",
     "yargs": "^17.2.1",
-    "express-rate-limit": "^7.4.1"
+    "express-rate-limit": "^7.4.1",
+    "escape-html": "^1.0.3"
   },
   "optionalDependencies": {
     "asciidoctor.js": "^1.5.9"

--- a/libs/scully/src/lib/utils/serverstuff/dataServer.ts
+++ b/libs/scully/src/lib/utils/serverstuff/dataServer.ts
@@ -1,7 +1,7 @@
 import { logOk, yellow } from '../';
 import { posts, users } from '../../testData';
 import { readDotProperty } from '../scullydot';
-
+import escape from 'escape-html';
 const express = require('express');
 
 export async function startDataServer(ssl: boolean) {
@@ -72,7 +72,7 @@ export async function startDataServer(ssl: boolean) {
     });
     dataServer.get('/*', (req, res) => {
       res.status(404);
-      res.send(`<h1>404 - ${req.url}</h1>`);
+      res.send(`<h1>404 - ${escape(req.url)}</h1>`);
     });
     return dataServer.listen(8200, hostName, (x) => {
       logOk(`Started Test data server on "${yellow(`http://${hostName}:${8200}/`)}" `);


### PR DESCRIPTION
Fixes [https://github.com/akaday/symmetrical-octo-barnacle/security/code-scanning/3](https://github.com/akaday/symmetrical-octo-barnacle/security/code-scanning/3)

To fix the reflected cross-site scripting vulnerability, we need to sanitize the user input before incorporating it into the HTML response. The best way to do this is by using a well-known library for escaping HTML, such as `escape-html`. This library will ensure that any special characters in the user input are properly escaped, preventing the execution of malicious scripts.

- **General Fix:** Sanitize the `req.url` value before including it in the HTML response.
- **Detailed Fix:** Import the `escape-html` library and use it to escape `req.url` on line 75.
- **Specific Changes:**
  - Import the `escape-html` library at the top of the file.
  - Use the `escape` function from the `escape-html` library to sanitize `req.url` before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
