### PR TITLE
Fix code scanning alert no. 17: Prototype-polluting assignment

### DIFF
--- a/libs/scully/src/lib/pluginManagement/pluginRepository.ts
+++ b/libs/scully/src/lib/pluginManagement/pluginRepository.ts
@@ -50,6 +50,9 @@ export const registerPlugin = <T extends keyof PluginFuncs>(
   pluginOptions?: ConfigValidator | number | string[],
   { replaceExistingPlugin = false }: RegisterOptions = {}
 ): void => {
+  if (!pluginTypes.includes(type)) {
+    throw new Error(`Invalid plugin type: ${type}`);
+  }
   const displayName = typeof name === 'string' ? name : name.description;
   if (typeof name === 'symbol') {
     logWarn(`${displayName} is a Symbol. Using those is deprecated. use "const x = 'myId' as const" instead`);


### PR DESCRIPTION
Fixes [https://github.com/akaday/symmetrical-octo-barnacle/security/code-scanning/17](https://github.com/akaday/symmetrical-octo-barnacle/security/code-scanning/17)

To fix the problem, we need to ensure that the `type` parameter cannot be used to modify `Object.prototype`. This can be achieved by validating the `type` parameter against the predefined list of plugin types before using it as a key in the `plugins` object. If the `type` is not one of the expected values, we should throw an error.

**Steps to fix:**
1. Validate the `type` parameter against the `pluginTypes` array.
2. If `type` is not a valid plugin type, throw an error.
3. Ensure that the `type` parameter is safe to use as a key in the `plugins` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
